### PR TITLE
feat: add item params to edit menu item handler

### DIFF
--- a/src/components/OverlayControls/OverlayControls.tsx
+++ b/src/components/OverlayControls/OverlayControls.tsx
@@ -46,7 +46,7 @@ export interface OverlayCustomControlItem {
     title?: string;
     icon?: MenuItemProps['icon'];
     iconSize?: number | string;
-    handler?: (item: ConfigItem) => void;
+    handler?: (item: ConfigItem, params: any) => void;
     visible?: (item: ConfigItem) => boolean;
     className?: string;
 }
@@ -195,7 +195,7 @@ class OverlayControls extends React.Component<OverlayControlsProps> {
     }
     private renderDropdownMenu() {
         const {view, size} = this.props;
-        const {registerManager} = this.context;
+        const {registerManager, itemsParams} = this.context;
 
         let menu = registerManager.settings.menu;
         if (!menu.length) {
@@ -219,7 +219,7 @@ class OverlayControls extends React.Component<OverlayControlsProps> {
 
                   const itemAction =
                       typeof itemHandler === 'function'
-                          ? () => itemHandler(this.props.configItem)
+                          ? () => itemHandler(this.props.configItem, itemsParams)
                           : this.getDropDownMenuItemConfig(item.id)?.action || (() => {});
 
                   return {

--- a/src/components/OverlayControls/OverlayControls.tsx
+++ b/src/components/OverlayControls/OverlayControls.tsx
@@ -14,7 +14,7 @@ import {
     MenuItemProps,
 } from '@gravity-ui/uikit';
 import {COPIED_WIDGET_STORE_KEY, MenuItems} from '../../constants';
-import {ConfigLayout, ConfigItem, PluginBase} from '../../shared';
+import {ConfigLayout, ConfigItem, PluginBase, StringParams} from '../../shared';
 import {DotsIcon} from '../../icons/DotsIcon';
 import {CogIcon} from '../../icons/CogIcon';
 import {CloseIcon} from '../../icons/CloseIcon';
@@ -46,7 +46,7 @@ export interface OverlayCustomControlItem {
     title?: string;
     icon?: MenuItemProps['icon'];
     iconSize?: number | string;
-    handler?: (item: ConfigItem, params: any) => void;
+    handler?: (item: ConfigItem, params: StringParams) => void;
     visible?: (item: ConfigItem) => boolean;
     className?: string;
 }
@@ -195,7 +195,11 @@ class OverlayControls extends React.Component<OverlayControlsProps> {
     }
     private renderDropdownMenu() {
         const {view, size} = this.props;
-        const {registerManager, itemsParams} = this.context;
+        const {registerManager} = this.context;
+
+        const itemsParams: Record<string, StringParams> = this.context.itemsParams;
+        const configItem = this.props.configItem;
+        const itemParams = itemsParams[configItem.id];
 
         let menu = registerManager.settings.menu;
         if (!menu.length) {
@@ -211,7 +215,7 @@ class OverlayControls extends React.Component<OverlayControlsProps> {
                       return null;
                   }
                   // custom menu dropdown item filter
-                  if (item.visible && !item.visible(this.props.configItem)) {
+                  if (item.visible && !item.visible(configItem)) {
                       return null;
                   }
 
@@ -219,7 +223,7 @@ class OverlayControls extends React.Component<OverlayControlsProps> {
 
                   const itemAction =
                       typeof itemHandler === 'function'
-                          ? () => itemHandler(this.props.configItem, itemsParams)
+                          ? () => itemHandler(configItem, itemParams)
                           : this.getDropDownMenuItemConfig(item.id)?.action || (() => {});
 
                   return {


### PR DESCRIPTION
for more custom edit menu handler need context or item prams property. I find it difficult to choose the best solution to pass to menu handler the whole context or just the item params object. What do you think is the best thing to do?