### PR TITLE
feat!: rename types in plugin Text

### DIFF
--- a/src/plugins/Text/Text.tsx
+++ b/src/plugins/Text/Text.tsx
@@ -153,14 +153,14 @@ export class PluginText extends React.PureComponent<PluginTextProps, PluginTextS
 
 type PluginDataProps = Omit<PluginTextProps, 'apiHandler'>;
 
-export type PluginObjectSettings = {apiHandler?: PluginTextApiHandler};
+export type PluginTextObjectSettings = {apiHandler?: PluginTextApiHandler};
 
-export type PluginObject = Plugin<PluginDataProps> & {
-    setSettings: (settings: PluginObjectSettings) => PluginObject;
+export type PluginTextObject = Plugin<PluginDataProps> & {
+    setSettings: (settings: PluginTextObjectSettings) => PluginTextObject;
     _apiHandler?: PluginTextApiHandler;
 };
 
-const plugin: PluginObject = {
+const plugin: PluginTextObject = {
     type: 'text',
     defaultLayout: {w: 12, h: 6},
     setSettings(settings) {

--- a/src/plugins/Text/index.ts
+++ b/src/plugins/Text/index.ts
@@ -1,8 +1,2 @@
-export {
-    PluginTextApiHandler,
-    PluginTextProps,
-    PluginText,
-    PluginObjectSettings as PluginTextObjectSettings,
-    PluginObject as PluginTextObject,
-    default as pluginText,
-} from './Text';
+export * from './Text';
+export {default as pluginText} from './Text';

--- a/src/plugins/Title/index.ts
+++ b/src/plugins/Title/index.ts
@@ -1,1 +1,2 @@
-export {PluginTitle, PluginTitleProps, default as pluginTitle} from './Title';
+export * from './Title';
+export {default as pluginTitle} from './Title';


### PR DESCRIPTION
Rename types in Text plugin: `PluginObject ` -> `PluginTextObject `, `PluginObjectSettings ` -> `PluginTextObjectSettings `