### PR TITLE
feat: add dash realtimeMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,21 @@ Before using `DashKit` as a react component, it must be configured.
   });
   ```
 
+## Settings
+
+### Autoupdate
+
+This functionality allows you to automatically update the items of the Dash. All items that should participate in the auto-update cycle must have the `reload` method.
+There are two auto-update scenarios available, the first - the classic interval to enable which is enough to pass the `autoupdateInterval` parameter and the second - the so-called `realtimeMode`.
+`realtimeMode` is useful in cases where dash items are updated at different rates and you cannot guarantee data consistency at a given time. `realtimeMode` is based on `Promise.allSettled`.
+
+| Name                | Description                                                                            |    Type   | Default |
+|:--------------------|:---------------------------------------------------------------------------------------|:---------:|:-------:|
+| autoupdateInterval  | The time, in **seconds**, the dash should delay in between executions auto-update      |  `number` |         |
+| realtimeMode        | Enable realtime mode                                                                   | `boolean` |         |
+| realtimeModeDelayMs | The time, in **milliseconds**, the dash should delay after all items have been updated |  `number` |   5000  |
+| silentLoading       | Items update status indicator. It will be passed into the Item `reload` method         | `boolean` |  false  |
+
 ### Config
 
 ```ts

--- a/src/components/DashKit/__stories__/DashKit.stories.tsx
+++ b/src/components/DashKit/__stories__/DashKit.stories.tsx
@@ -6,6 +6,7 @@ import pluginTitle from '../../../plugins/Title/Title';
 import pluginText from '../../../plugins/Text/Text';
 import {DashKitShowcase} from './DashKitShowcase';
 import {getConfig} from './utils';
+import {DashKitUpdateItems} from './DashKitUpodateItems/DashKitUpodateItems';
 import './DashKit.stories.scss';
 
 const b = cn('stories-dashkit');
@@ -69,3 +70,6 @@ export const Default = DefaultTemplate.bind({});
 
 const ShowcaseTemplate: Story = () => <DashKitShowcase />;
 export const Showcase = ShowcaseTemplate.bind({});
+
+const DashKitUpdateItemsTempl = () => <DashKitUpdateItems />;
+export const UpdateItems = DashKitUpdateItemsTempl.bind({});

--- a/src/components/DashKit/__stories__/DashKitUpodateItems/DashKitUpodateItems.tsx
+++ b/src/components/DashKit/__stories__/DashKitUpodateItems/DashKitUpodateItems.tsx
@@ -1,0 +1,135 @@
+import React, {useEffect} from 'react';
+import {Demo, DemoRow} from '../Demo';
+import {DashKit} from '../../DashKit';
+import {Plugin} from '../../../../typings';
+import {PluginTitleProps} from '../../../../../src/plugins';
+import {TitleWithReq, TitleWithReqProps} from './TitleWithReq/TitleWithReq';
+import {RadioGroup} from '@gravity-ui/uikit';
+import {destroyStore, initStore} from './MockStore/MockStore';
+import {StorageWidget} from './StorageWidget/StorageWidget';
+
+const pluginTitle: Plugin<TitleWithReqProps> = {
+    type: 'TitleWithReq',
+    renderer(props, forwardedRef) {
+        return <TitleWithReq {...props} ref={forwardedRef} />;
+    },
+};
+const pluginStorageWidget: Plugin<PluginTitleProps> = {
+    type: 'StorageWidget',
+    renderer(props) {
+        return <StorageWidget {...props} />;
+    },
+};
+
+DashKit.registerPlugins(pluginTitle, pluginStorageWidget);
+
+const config = {
+    salt: '0.46703554571365613',
+    counter: 5,
+    aliases: {},
+    connections: [],
+    items: [
+        {
+            id: 'FastUpdateTitle',
+            data: {
+                size: 'm',
+                text: 'Fast',
+                reqDelay: 3,
+            },
+            type: 'TitleWithReq',
+            namespace: 'default',
+            orderId: 1,
+        },
+        {
+            id: 'SlowUpdateTitle',
+            data: {
+                size: 'm',
+                text: 'Slow',
+                reqDelay: 6,
+            },
+            type: 'TitleWithReq',
+            namespace: 'default',
+            orderId: 1,
+        },
+        {
+            id: 'Store',
+            data: {
+                size: 'm',
+                text: 'Store',
+            },
+            type: 'StorageWidget',
+            namespace: 'default',
+            orderId: 1,
+        },
+    ],
+    layout: [
+        {
+            h: 4,
+            i: 'FastUpdateTitle',
+            w: 26,
+            x: 0,
+            y: 0,
+        },
+        {
+            h: 4,
+            i: 'SlowUpdateTitle',
+            w: 26,
+            x: 0,
+            y: 0,
+        },
+        {
+            h: 8,
+            i: 'Store',
+            w: 10,
+            x: 26,
+            y: 0,
+        },
+    ],
+};
+
+export const DashKitUpdateItems = () => {
+    const [autoUpdateMode, setAutoUpdateMode] = React.useState('update10s');
+    const [autoupdateInterval, setAutoupdateInterval] = React.useState(10);
+    const [realtimeMode, setRealtimeMode] = React.useState(false);
+
+    useEffect(() => {
+        initStore();
+        return () => {
+            destroyStore();
+        };
+    }, []);
+
+    return (
+        <Demo title="DashKit Update Items">
+            <DemoRow title="Controls">
+                <RadioGroup
+                    value={autoUpdateMode}
+                    onUpdate={(value) => {
+                        setAutoUpdateMode(value);
+                        switch (value) {
+                            case 'update10s':
+                                setAutoupdateInterval(10);
+                                break;
+                            case 'update1s':
+                                setAutoupdateInterval(1);
+                                break;
+                            case 'realtime':
+                                setRealtimeMode(true);
+                                break;
+                        }
+                    }}
+                    options={[
+                        {value: 'update10s', content: 'Set autoupdate interval to 10s'},
+                        {value: 'update1s', content: 'Set autoupdate interval to 1s'},
+                        {value: 'realtime', content: 'Set Realtime Mode'},
+                    ]}
+                />
+            </DemoRow>
+            <DashKit
+                config={config}
+                editMode={false}
+                settings={{autoupdateInterval, realtimeMode, silentLoading: false}}
+            />
+        </Demo>
+    );
+};

--- a/src/components/DashKit/__stories__/DashKitUpodateItems/DashKitUpodateItems.tsx
+++ b/src/components/DashKit/__stories__/DashKitUpodateItems/DashKitUpodateItems.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect} from 'react';
 import {Demo, DemoRow} from '../Demo';
 import {DashKit} from '../../DashKit';
-import {Plugin} from '../../../../typings';
+import {Plugin, SettingsProps} from '../../../../typings';
 import {PluginTitleProps} from '../../../../../src/plugins';
 import {TitleWithReq, TitleWithReqProps} from './TitleWithReq/TitleWithReq';
 import {RadioGroup} from '@gravity-ui/uikit';
@@ -87,10 +87,14 @@ const config = {
     ],
 };
 
+const settingsByMode: Record<string, Partial<SettingsProps>> = {
+    realtime: {realtimeMode: true},
+    update1s: {autoupdateInterval: 1},
+    update10s: {autoupdateInterval: 10},
+};
+
 export const DashKitUpdateItems = () => {
-    const [autoUpdateMode, setAutoUpdateMode] = React.useState('update10s');
-    const [autoupdateInterval, setAutoupdateInterval] = React.useState(10);
-    const [realtimeMode, setRealtimeMode] = React.useState(false);
+    const [autoUpdateMode, setAutoUpdateMode] = React.useState('realtime');
 
     useEffect(() => {
         initStore();
@@ -106,17 +110,6 @@ export const DashKitUpdateItems = () => {
                     value={autoUpdateMode}
                     onUpdate={(value) => {
                         setAutoUpdateMode(value);
-                        switch (value) {
-                            case 'update10s':
-                                setAutoupdateInterval(10);
-                                break;
-                            case 'update1s':
-                                setAutoupdateInterval(1);
-                                break;
-                            case 'realtime':
-                                setRealtimeMode(true);
-                                break;
-                        }
                     }}
                     options={[
                         {value: 'update10s', content: 'Set autoupdate interval to 10s'},
@@ -128,7 +121,10 @@ export const DashKitUpdateItems = () => {
             <DashKit
                 config={config}
                 editMode={false}
-                settings={{autoupdateInterval, realtimeMode, silentLoading: false}}
+                settings={{
+                    silentLoading: false,
+                    ...settingsByMode[autoUpdateMode],
+                }}
             />
         </Demo>
     );

--- a/src/components/DashKit/__stories__/DashKitUpodateItems/MockStore/MockStore.ts
+++ b/src/components/DashKit/__stories__/DashKitUpodateItems/MockStore/MockStore.ts
@@ -1,0 +1,35 @@
+let store = {
+    counter: 0,
+    updateInterval: 1,
+};
+
+type StoreUpdateCallback = (state: typeof store) => void;
+const onUpdateCallbacks: Array<StoreUpdateCallback> = [];
+
+let interval: NodeJS.Timer | undefined;
+
+export const storeOnUpdateSubscribe = (callback: StoreUpdateCallback) => {
+    onUpdateCallbacks.push(callback);
+};
+
+export const initStore = () => {
+    if (interval) return;
+
+    store.counter = 0;
+
+    interval = setInterval(() => {
+        store = {...store, counter: store.counter + 1};
+        onUpdateCallbacks.forEach((callback) => {
+            callback(store);
+        });
+    }, store.updateInterval * 1000);
+};
+
+export const destroyStore = () => {
+    clearInterval(interval);
+    interval = undefined;
+};
+
+export const getStore = () => {
+    return store;
+};

--- a/src/components/DashKit/__stories__/DashKitUpodateItems/StorageWidget/StorageWidget.tsx
+++ b/src/components/DashKit/__stories__/DashKitUpodateItems/StorageWidget/StorageWidget.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import {PluginTitleProps} from '../../../../../plugins';
+
+import {getStore, storeOnUpdateSubscribe} from '../MockStore/MockStore';
+import {Card, Flex, Text} from '@gravity-ui/uikit';
+import '../styles.scss';
+
+export const StorageWidget = (props: PluginTitleProps) => {
+    const [storeState, setStoreState] = React.useState<any>(getStore());
+
+    React.useEffect(() => {
+        storeOnUpdateSubscribe((store) => {
+            setStoreState({...store});
+        });
+    }, [setStoreState]);
+
+    return (
+        <Card theme="info" view="filled" className="cardLayout">
+            <div>
+                <Text variant="display-1">{props.data.text}</Text>
+                <div>{`counter: ${storeState.counter}`}</div>
+            </div>
+            <Flex justifyContent="flex-end">
+                <span>{`update interval: ${storeState.updateInterval}s`}</span>
+            </Flex>
+        </Card>
+    );
+};

--- a/src/components/DashKit/__stories__/DashKitUpodateItems/StorageWidget/StorageWidget.tsx
+++ b/src/components/DashKit/__stories__/DashKitUpodateItems/StorageWidget/StorageWidget.tsx
@@ -6,7 +6,7 @@ import {Card, Flex, Text} from '@gravity-ui/uikit';
 import '../styles.scss';
 
 export const StorageWidget = (props: PluginTitleProps) => {
-    const [storeState, setStoreState] = React.useState<any>(getStore());
+    const [storeState, setStoreState] = React.useState<ReturnType<typeof getStore>>(getStore());
 
     React.useEffect(() => {
         storeOnUpdateSubscribe((store) => {

--- a/src/components/DashKit/__stories__/DashKitUpodateItems/TitleWithReq/TitleWithReq.tsx
+++ b/src/components/DashKit/__stories__/DashKitUpodateItems/TitleWithReq/TitleWithReq.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import {PluginTitleProps} from '../../../../../../src/plugins';
+
+import {getStore} from '../MockStore/MockStore';
+import {Card, Flex, Text} from '@gravity-ui/uikit';
+import '../styles.scss';
+
+const getData = (timeout = 1000) => {
+    return new Promise<string | number>((res) => {
+        const counter = getStore().counter;
+        setTimeout(() => {
+            res(counter);
+        }, timeout);
+    });
+};
+
+export type TitleWithReqProps = {
+    data: {reqDelay: number} & PluginTitleProps['data'];
+} & PluginTitleProps;
+type TitleWithReqState = {
+    isLoading: boolean;
+    counter?: string | number;
+};
+
+export class TitleWithReq extends React.Component<TitleWithReqProps, TitleWithReqState> {
+    componentDidMount(): void {
+        this.reload();
+    }
+
+    render() {
+        return (
+            <Card theme="normal" view="filled" className="cardLayout">
+                <div>
+                    <Text variant="display-1">{this.props.data.text}</Text>
+                    <Flex justifyContent="space-between">
+                        <span>{`counter: ${this.state?.counter}`}</span>
+                        {this.state?.isLoading && <span>Loading...</span>}
+                    </Flex>
+                </div>
+                <Flex justifyContent="flex-end">
+                    <span>{`update interval: ${this.props.data.reqDelay}s`}</span>
+                </Flex>
+            </Card>
+        );
+    }
+
+    async reload() {
+        this.setState({isLoading: true});
+        await getData(this.props.data.reqDelay * 1000).then((counter) => {
+            this.setState({counter, isLoading: false});
+        });
+    }
+}

--- a/src/components/DashKit/__stories__/DashKitUpodateItems/TitleWithReq/TitleWithReq.tsx
+++ b/src/components/DashKit/__stories__/DashKitUpodateItems/TitleWithReq/TitleWithReq.tsx
@@ -5,11 +5,17 @@ import {getStore} from '../MockStore/MockStore';
 import {Card, Flex, Text} from '@gravity-ui/uikit';
 import '../styles.scss';
 
+const resOreRej = () => Math.round(Math.random());
+
 const getData = (timeout = 1000) => {
-    return new Promise<string | number>((res) => {
+    return new Promise<string | number>((res, rej) => {
         const counter = getStore().counter;
         setTimeout(() => {
-            res(counter);
+            if (resOreRej()) {
+                res(counter);
+            } else {
+                rej();
+            }
         }, timeout);
     });
 };
@@ -20,16 +26,17 @@ export type TitleWithReqProps = {
 type TitleWithReqState = {
     isLoading: boolean;
     counter?: string | number;
+    error: boolean;
 };
 
 export class TitleWithReq extends React.Component<TitleWithReqProps, TitleWithReqState> {
-    componentDidMount(): void {
-        this.reload();
-    }
-
     render() {
         return (
-            <Card theme="normal" view="filled" className="cardLayout">
+            <Card
+                theme={this.state?.error ? 'danger' : 'normal'}
+                view="filled"
+                className="cardLayout"
+            >
                 <div>
                     <Text variant="display-1">{this.props.data.text}</Text>
                     <Flex justifyContent="space-between">
@@ -44,10 +51,14 @@ export class TitleWithReq extends React.Component<TitleWithReqProps, TitleWithRe
         );
     }
 
-    async reload() {
+    reload() {
         this.setState({isLoading: true});
-        await getData(this.props.data.reqDelay * 1000).then((counter) => {
-            this.setState({counter, isLoading: false});
-        });
+        return getData(this.props.data.reqDelay * 1000)
+            .then((counter) => {
+                this.setState({counter, isLoading: false, error: false});
+            })
+            .catch(() => {
+                this.setState({counter: undefined, isLoading: false, error: true});
+            });
     }
 }

--- a/src/components/DashKit/__stories__/DashKitUpodateItems/TitleWithReq/TitleWithReq.tsx
+++ b/src/components/DashKit/__stories__/DashKitUpodateItems/TitleWithReq/TitleWithReq.tsx
@@ -58,7 +58,7 @@ export class TitleWithReq extends React.Component<TitleWithReqProps, TitleWithRe
                 this.setState({counter, isLoading: false, error: false});
             })
             .catch(() => {
-                this.setState({counter: undefined, isLoading: false, error: true});
+                this.setState({counter: 'Failed request', isLoading: false, error: true});
             });
     }
 }

--- a/src/components/DashKit/__stories__/DashKitUpodateItems/styles.scss
+++ b/src/components/DashKit/__stories__/DashKitUpodateItems/styles.scss
@@ -1,0 +1,7 @@
+.cardLayout {
+    padding: 8px;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}

--- a/src/components/GridLayout/GridLayout.js
+++ b/src/components/GridLayout/GridLayout.js
@@ -70,12 +70,29 @@ export default class GridLayout extends React.PureComponent {
         return getItemsMeta(this.pluginsRefs);
     };
 
+    startReloadItems() {
+        const {editMode, settings: {silentLoading} = {}, reloadItems} = this.context;
+        const {isPageHidden} = this.state;
+
+        if (!isPageHidden && !editMode) {
+            this._lastReloadAt = new Date().getTime();
+            return reloadItems(this.pluginsRefs, {silentLoading, noVeil: true});
+        }
+
+        return Promise.resolve();
+    }
+
     reloadItems() {
         const {
             editMode,
-            settings: {autoupdateInterval, silentLoading} = {},
+            settings: {autoupdateInterval, silentLoading, realtimeMode} = {},
             reloadItems,
         } = this.context;
+
+        if (realtimeMode) {
+            this.startReloadItems().then(this.reloadItems);
+            return;
+        }
         const {isPageHidden} = this.state;
         const autoupdateIntervalMs = Number(autoupdateInterval) * 1000;
         if (autoupdateIntervalMs) {

--- a/src/components/GridLayout/GridLayout.js
+++ b/src/components/GridLayout/GridLayout.js
@@ -103,7 +103,9 @@ export default class GridLayout extends React.PureComponent {
         const {settings: {realtimeMode, realtimeModeDelayMs = 5000} = {}} = this.context;
 
         if (realtimeMode) {
-            this.startReloadItems().then(() => this.startReloadItemsTimeout(realtimeModeDelayMs));
+            this.startReloadItems().then(() => {
+                this.startReloadItemsTimeout(realtimeModeDelayMs);
+            });
             return;
         }
 

--- a/src/components/GridLayout/GridLayout.js
+++ b/src/components/GridLayout/GridLayout.js
@@ -36,9 +36,16 @@ export default class GridLayout extends React.PureComponent {
     _lastReloadAt;
 
     onVisibilityChange = () => {
-        this.setState({
-            isPageHidden: document.hidden,
-        });
+        this.setState(
+            {
+                isPageHidden: document.hidden,
+            },
+            () => {
+                if (!this.state.isPageHidden) {
+                    this.forceReloadItems();
+                }
+            },
+        );
     };
 
     adjustWidgetLayout = ({widgetId, needSetDefault, adjustedWidgetLayout}) => {

--- a/src/components/GridLayout/GridLayout.js
+++ b/src/components/GridLayout/GridLayout.js
@@ -95,11 +95,15 @@ export default class GridLayout extends React.PureComponent {
         return Promise.resolve();
     }
 
+    startReloadItemsTimeout(timeoutMs) {
+        this._timeout = setTimeout(() => this.reloadItems(), timeoutMs);
+    }
+
     reloadItems() {
-        const {settings: {realtimeMode} = {}} = this.context;
+        const {settings: {realtimeMode, realtimeModeDelayMs = 5000} = {}} = this.context;
 
         if (realtimeMode) {
-            this.startReloadItems().then(() => this.reloadItems());
+            this.startReloadItems().then(() => this.startReloadItemsTimeout(realtimeModeDelayMs));
             return;
         }
 
@@ -110,8 +114,7 @@ export default class GridLayout extends React.PureComponent {
                 this.startReloadItems();
             }
 
-            this._timeout = setTimeout(
-                () => this.reloadItems(),
+            this.startReloadItemsTimeout(
                 reloadIntervalRemains <= 0 ? autoupdateIntervalMs : reloadIntervalRemains,
             );
         }

--- a/src/hocs/withContext.js
+++ b/src/hocs/withContext.js
@@ -173,7 +173,7 @@ function useMemoStateContext(props) {
 
     const reloadItems = React.useCallback((pluginsRefs, data) => {
         const promises = pluginsRefs.map((ref) => ref && ref.reload && ref.reload(data));
-        return Promise.all(promises);
+        return Promise.allSettled(promises);
     }, []);
 
     return React.useMemo(

--- a/src/hocs/withContext.js
+++ b/src/hocs/withContext.js
@@ -172,7 +172,8 @@ function useMemoStateContext(props) {
     }, [props.layout, layoutUpdateCounter]);
 
     const reloadItems = React.useCallback((pluginsRefs, data) => {
-        pluginsRefs.forEach((ref) => ref && ref.reload && ref.reload(data));
+        const promises = pluginsRefs.map((ref) => ref && ref.reload && ref.reload(data));
+        return Promise.all(promises);
     }, []);
 
     return React.useMemo(

--- a/src/typings/common.ts
+++ b/src/typings/common.ts
@@ -13,9 +13,10 @@ export interface Settings {
 export type MenuItem = (typeof MenuItems)[keyof typeof MenuItems] | OverlayCustomControlItem;
 
 export interface SettingsProps {
-    autoupdateInterval: number;
+    autoupdateInterval?: number;
     silentLoading: boolean;
     realtimeMode?: boolean;
+    realtimeModeDelayMs?: number;
 }
 
 export interface ContextProps {

--- a/src/typings/common.ts
+++ b/src/typings/common.ts
@@ -15,6 +15,7 @@ export type MenuItem = (typeof MenuItems)[keyof typeof MenuItems] | OverlayCusto
 export interface SettingsProps {
     autoupdateInterval: number;
     silentLoading: boolean;
+    realtimeMode?: boolean;
 }
 
 export interface ContextProps {


### PR DESCRIPTION
Add so-called `realtimeMode` auto-update dash scenario.
`realtimeMode` is useful in cases where dash items are updated at different rates and you cannot guarantee data consistency at a given time. `realtimeMode` is based on `Promise.allSettled`.