### PR TITLE
fix: refact getItemsParams for action params

### DIFF
--- a/src/shared/modules/helpers.ts
+++ b/src/shared/modules/helpers.ts
@@ -3,7 +3,6 @@ import get from 'lodash/get';
 import invert from 'lodash/invert';
 import isEmpty from 'lodash/isEmpty';
 import pick from 'lodash/pick';
-import intersection from 'lodash/intersection';
 import {META_KEY, CURRENT_VERSION, ACTION_PARAM_PREFIX} from '../constants';
 import {
     PluginBase,
@@ -361,36 +360,4 @@ export function hasActionParams(stateAndParams: ItemStateAndParams) {
     }
 
     return hasActionParam(stateAndParams.params);
-}
-
-/**
- * Collect array of actionParams keys with prefix (_ap_) that must be cleared from widget defaults
- * @param defaultWidgetParams
- * @param queueWidgetParams
- */
-export function getDefaultsActionParamsToClear({
-    defaultWidgetParams,
-    queueWidgetParams,
-}: {
-    defaultWidgetParams: StringParams;
-    queueWidgetParams: StringParams;
-}) {
-    const widgetDefaultsWithActionParams = hasActionParam(defaultWidgetParams)
-        ? pickActionParamsFromParams(defaultWidgetParams)
-        : null;
-
-    if (!widgetDefaultsWithActionParams) {
-        return [];
-    }
-
-    // clear default actionParams if some param with the same name without prefix affected on current widget
-    // ex.: queueWidgetParams contain {Year: 1970} and default actionParams contain {_ap_Year: 2000}
-    const actionParamKeyToClear: string[] = intersection(
-        Object.keys(queueWidgetParams),
-        Object.keys(widgetDefaultsWithActionParams),
-    );
-
-    return actionParamKeyToClear.length
-        ? actionParamKeyToClear.map((key) => `${ACTION_PARAM_PREFIX}${key}`)
-        : [];
 }

--- a/src/shared/units/__tests__/configs.json
+++ b/src/shared/units/__tests__/configs.json
@@ -472,6 +472,103 @@
                 ]
             },
             "connections": []
+        },
+        {
+            "salt": "0.09852189776033704",
+            "counter": 14,
+            "items": [
+                {
+                    "id": "al",
+                    "data": {
+                        "tabs": [
+                            {
+                                "id": "Jn",
+                                "title": "Заголовок 1",
+                                "params": {},
+                                "chartId": "h8hfbffyo3dg8",
+                                "isDefault": true,
+                                "autoHeight": false
+                            }
+                        ],
+                        "hideTitle": true
+                    },
+                    "type": "widget",
+                    "namespace": "default"
+                },
+                {
+                    "id": "Q8",
+                    "data": {
+                        "tabs": [
+                            {
+                                "id": "K0",
+                                "title": "chart 1",
+                                "params": {
+                                    "Year": "",
+                                    "Country": "",
+                                    "Name": "",
+                                    "Price": ""
+                                },
+                                "chartId": "245z37u4ylvet",
+                                "enableActionParams": true,
+                                "isDefault": true,
+                                "autoHeight": false
+                            }
+                        ],
+                        "hideTitle": false
+                    },
+                    "type": "widget",
+                    "namespace": "default"
+                },
+                {
+                    "id": "L5",
+                    "data": {
+                        "tabs": [
+                            {
+                                "id": "K1",
+                                "title": "chart 2",
+                                "params": {
+                                    "Year": "",
+                                    "Country": "",
+                                    "Name": "",
+                                    "Price": ""
+                                },
+                                "chartId": "r77ztfu4yl5ew",
+                                "enableActionParams": true,
+                                "isDefault": true,
+                                "autoHeight": false
+                            }
+                        ],
+                        "hideTitle": false
+                    },
+                    "type": "widget",
+                    "namespace": "default"
+                }
+            ],
+            "layout": [
+                {
+                    "h": 4,
+                    "i": "al",
+                    "w": 4,
+                    "x": 8,
+                    "y": 0
+                },
+                {
+                    "h": 16,
+                    "i": "Q8",
+                    "w": 12,
+                    "x": 12,
+                    "y": 0
+                },
+                {
+                    "h": 2,
+                    "i": "L5",
+                    "w": 8,
+                    "x": 0,
+                    "y": 2
+                }
+            ],
+            "aliases": {},
+            "connections": []
         }
     ]
 }

--- a/src/shared/units/__tests__/state-and-params.test.ts
+++ b/src/shared/units/__tests__/state-and-params.test.ts
@@ -308,6 +308,7 @@ const stateAndParamsForAP2 = {
                 Country: 'Belgium',
                 Year: '',
                 'd079937f-6bc4-4133-9171-40092bb20d6f': 'Belgium',
+                _ap_Country: 'Italy',
             },
             state: {},
         },
@@ -337,6 +338,7 @@ const stateAndParamsForAP3 = {
                 Country: '',
                 Year: '',
                 'd079937f-6bc4-4133-9171-40092bb20d6f': '',
+                _ap_Country: 'Italy',
             },
             state: {},
         },
@@ -410,6 +412,65 @@ const stateAndParamsForAP5 = {
             params: {
                 Country: ['Italy', 'France'],
                 'd079937f-6bc4-4133-9171-40092bb20d6f': ['Italy', 'France'],
+            },
+            state: {},
+        },
+    },
+};
+
+const stateAndParamsForAP6 = {
+    in: {
+        Q8: {
+            params: {
+                _ap_Year: '2021',
+                _ap_Country: 'Russia',
+            },
+        },
+        L5: {
+            params: {
+                _ap_Country: 'Russia',
+                _ap_Name: 'Alex',
+                _ap_Price: '1000',
+            },
+        },
+        __meta__: {
+            queue: [
+                {id: 'Q8', tabId: 'K0'},
+                {id: 'L5', tabId: 'K1'},
+            ],
+            version: 2,
+        },
+    },
+    out: {
+        L5: {
+            params: {
+                Name: '',
+                Price: '',
+                Year: '2021',
+                Country: 'Russia',
+                _ap_Country: 'Russia',
+                _ap_Name: 'Alex',
+                _ap_Price: '1000',
+            },
+            state: {},
+        },
+        Q8: {
+            params: {
+                Year: '',
+                Country: 'Russia',
+                Name: 'Alex',
+                Price: '1000',
+                _ap_Year: '2021',
+                _ap_Country: 'Russia',
+            },
+            state: {},
+        },
+        al: {
+            params: {
+                Country: 'Russia',
+                Name: 'Alex',
+                Price: '1000',
+                Year: '2021',
             },
             state: {},
         },
@@ -522,6 +583,19 @@ describe('getItemsStateAndParams actionParams variants check', () => {
 
         it('return stateAndParamsForAP5.out', () => {
             expect(resultItemsStateAndParams).toEqual(omit(stateAndParamsForAP5.out, META_KEY));
+        });
+    });
+
+    describe('action and params state 6', () => {
+        const resultItemsStateAndParams = getItemsStateAndParamsDL({
+            defaultGlobalParams: {},
+            globalParams: {},
+            config: configs[4],
+            itemsStateAndParams: stateAndParamsForAP6.in,
+        });
+
+        it('return stateAndParamsForAP6.out', () => {
+            expect(resultItemsStateAndParams).toEqual(omit(stateAndParamsForAP6.out, META_KEY));
         });
     });
 });


### PR DESCRIPTION
We should not clear the action params for the action widget.
For example. If a widget passed the parameter `_ap_Year: '2021'` then this parameter should always be present in the widget parameters.