### PR TITLE
feat: added options to plugin onStateAndParamsChange

### DIFF
--- a/src/hocs/prepareItem.js
+++ b/src/hocs/prepareItem.js
@@ -33,8 +33,8 @@ export function prepareItem(Component) {
 
         static contextType = DashKitContext;
 
-        _onStateAndParamsChange = (stateAndParams) => {
-            this.context.onItemStateAndParamsChange(this.props.id, stateAndParams);
+        _onStateAndParamsChange = (stateAndParams, options) => {
+            this.context.onItemStateAndParamsChange(this.props.id, stateAndParams, options);
         };
 
         render() {

--- a/src/hocs/withContext.js
+++ b/src/hocs/withContext.js
@@ -76,13 +76,14 @@ function useMemoStateContext(props) {
     );
 
     const onItemStateAndParamsChange = React.useCallback(
-        (id, stateAndParams) => {
+        (id, stateAndParams, options) => {
             onChange({
                 itemsStateAndParams: UpdateManager.changeStateAndParams({
                     id,
                     config: props.config,
                     stateAndParams,
                     itemsStateAndParams: props.itemsStateAndParams,
+                    options,
                 }),
             });
         },

--- a/src/shared/types/state-and-params.ts
+++ b/src/shared/types/state-and-params.ts
@@ -25,7 +25,7 @@ export type ItemStateAndParams = {
 };
 
 export type ItemStateAndParamsChangeOptions = {
-    action: 'setParams' | 'remove';
+    action: 'setParams' | 'removeItem';
 };
 
 export type ItemsStateAndParamsBase = Record<string, ItemStateAndParams>;

--- a/src/shared/types/state-and-params.ts
+++ b/src/shared/types/state-and-params.ts
@@ -24,6 +24,10 @@ export type ItemStateAndParams = {
     state?: ItemState;
 };
 
+export type ItemStateAndParamsChangeOptions = {
+    action: 'setParams' | 'remove';
+};
+
 export type ItemsStateAndParamsBase = Record<string, ItemStateAndParams>;
 
 export type ItemsStateAndParams = ItemsStateAndParamsBase | StateAndParamsMeta;

--- a/src/typings/plugin.ts
+++ b/src/typings/plugin.ts
@@ -1,6 +1,13 @@
 import React from 'react';
 import {ContextProps, SettingsProps, WidgetLayout} from './common';
-import {StringParams, ConfigItem, ItemState, ItemStateAndParams, PluginBase} from '../shared';
+import {
+    StringParams,
+    ConfigItem,
+    ItemState,
+    ItemStateAndParams,
+    PluginBase,
+    ItemStateAndParamsChangeOptions,
+} from '../shared';
 
 import type {ReactGridLayoutProps} from 'react-grid-layout';
 
@@ -9,7 +16,10 @@ export interface PluginWidgetProps {
     editMode: boolean;
     params: StringParams;
     state: ItemState;
-    onStateAndParamsChange: (stateAndParams: ItemStateAndParams) => void;
+    onStateAndParamsChange: (
+        stateAndParams: ItemStateAndParams,
+        options?: ItemStateAndParamsChangeOptions,
+    ) => void;
     width: number;
     height: number;
     data: ConfigItem['data'];

--- a/src/utils/__tests__/update-manager.test.ts
+++ b/src/utils/__tests__/update-manager.test.ts
@@ -412,7 +412,7 @@ describe('UpdateManager', () => {
                         },
                     },
                     stateAndParams: {},
-                    options: {action: 'remove'},
+                    options: {action: 'removeItem'},
                 }),
             ).toEqual({
                 L5: {
@@ -439,7 +439,7 @@ describe('UpdateManager', () => {
                         },
                     },
                     stateAndParams: {},
-                    options: {action: 'remove'},
+                    options: {action: 'removeItem'},
                 }),
             ).toEqual({
                 L5: {

--- a/src/utils/__tests__/update-manager.test.ts
+++ b/src/utils/__tests__/update-manager.test.ts
@@ -349,7 +349,7 @@ describe('UpdateManager', () => {
             });
         });
 
-        it('filtering_charts_table cannot set action params not from defaults', () => {
+        it('filtering_charts_table can set action params not from defaults', () => {
             expect(
                 UpdateManager.changeStateAndParams({
                     id: 'Q8',
@@ -373,10 +373,134 @@ describe('UpdateManager', () => {
                     },
                     params: {
                         _ap_Country: 'Germany',
+                        _ap_Brand: 'Pule',
                         _ap_Year: '2020',
                     },
                 },
                 __meta__: {queue: [{id: 'Q8', tabId: 'K0'}], version: 2},
+            });
+        });
+
+        it('the item is correctly removed from the queue', () => {
+            expect(
+                UpdateManager.changeStateAndParams({
+                    id: 'Q8',
+                    config,
+                    itemsStateAndParams: {
+                        L5: {
+                            params: {
+                                d079: ['Russia'],
+                            },
+                        },
+                        Q8: {
+                            state: {
+                                tabId: 'K0',
+                            },
+                            params: {
+                                _ap_Country: 'Germany',
+                                _ap_Year: '2020',
+                            },
+                        },
+                        Unk: {
+                            params: {
+                                Country: 'Unknown',
+                            },
+                        },
+                        __meta__: {
+                            queue: [{id: 'Q8', tabId: 'K0'}, {id: 'Unk'}, {id: 'L5'}],
+                            version: 2,
+                        },
+                    },
+                    stateAndParams: {},
+                    options: {action: 'remove'},
+                }),
+            ).toEqual({
+                L5: {
+                    params: {
+                        d079: ['Russia'],
+                    },
+                },
+                __meta__: {queue: [{id: 'L5'}], version: 2},
+            });
+
+            expect(
+                UpdateManager.changeStateAndParams({
+                    id: 'Q8',
+                    config,
+                    itemsStateAndParams: {
+                        L5: {
+                            params: {
+                                d079: ['Russia'],
+                            },
+                        },
+                        __meta__: {
+                            queue: [{id: 'L5'}],
+                            version: 2,
+                        },
+                    },
+                    stateAndParams: {},
+                    options: {action: 'remove'},
+                }),
+            ).toEqual({
+                L5: {
+                    params: {
+                        d079: ['Russia'],
+                    },
+                },
+                __meta__: {queue: [{id: 'L5'}], version: 2},
+            });
+        });
+
+        it('the item is correctly setParams using additional options', () => {
+            expect(
+                UpdateManager.changeStateAndParams({
+                    id: 'Q8',
+                    config,
+                    itemsStateAndParams: {
+                        L5: {
+                            params: {
+                                d079: ['Russia'],
+                            },
+                        },
+                        Q8: {
+                            state: {
+                                tabId: 'K0',
+                            },
+                            params: {
+                                _ap_Country: 'Germany',
+                                _ap_Year: '2020',
+                            },
+                        },
+                        __meta__: {
+                            queue: [{id: 'Q8', tabId: 'K0'}, {id: 'L5'}],
+                            version: 2,
+                        },
+                    },
+                    stateAndParams: {
+                        state: {
+                            tabId: 'K0',
+                        },
+                        params: {
+                            _ap_Country: 'Russia',
+                        },
+                    },
+                    options: {action: 'setParams'},
+                }),
+            ).toEqual({
+                L5: {
+                    params: {
+                        d079: ['Russia'],
+                    },
+                },
+                Q8: {
+                    state: {
+                        tabId: 'K0',
+                    },
+                    params: {
+                        _ap_Country: 'Russia',
+                    },
+                },
+                __meta__: {queue: [{id: 'L5'}, {id: 'Q8', tabId: 'K0'}], version: 2},
             });
         });
     });

--- a/src/utils/update-manager.ts
+++ b/src/utils/update-manager.ts
@@ -383,7 +383,7 @@ export class UpdateManager {
         const isTabSwitched = isItemWithTabs(initiatorItem) && Boolean(newTabId);
         const currentMeta = getItemsStateAndParamsMeta(itemsStateAndParams);
 
-        if (action === 'remove') {
+        if (action === 'removeItem') {
             return update(itemsStateAndParams, {
                 $unset: [...unusedIds, initiatorId],
                 [META_KEY]: {


### PR DESCRIPTION
- Added additional optional args to the plugin props onStateAndParamsChange allowing remove the item from queue or set params instead of merge.
- Action parameters are not associated with the default item params. The item can set any action params.