### PR TITLE
perf: avoid quadratic accumulator rebuilds in item params

### DIFF
--- a/src/shared/modules/helpers.ts
+++ b/src/shared/modules/helpers.ts
@@ -207,34 +207,32 @@ export function getMapItemsIgnores({
     isFirstVersion: boolean;
 }): Record<string, string[]> {
     // Record<itemId, innerId (tabId | itemId)>
-    const mapIds = items.reduce((acc: Record<string, string>, item) => {
-        return {
-            ...acc,
-            [item.id]: isItemWithTabs(item)
-                ? resolveItemInnerId({item, itemsStateAndParams})
-                : item.id,
-        };
-    }, {});
+    const mapIds: Record<string, string> = {};
+    for (const item of items) {
+        mapIds[item.id] = isItemWithTabs(item)
+            ? resolveItemInnerId({item, itemsStateAndParams})
+            : item.id;
+    }
     // Record<innerId (tabId | itemId), itemId>
     const invertedMapIds = invert(mapIds);
-    return items.reduce((acc: Record<string, string[]>, item) => {
-        return {
-            ...acc,
-            [item.id]: ignores
-                .filter(({from, to}) => {
-                    if (isFirstVersion) {
-                        // В первой версии был баг - если есть игнор на один таб, то весь виджет игнорит селектор.
-                        // Повторяем это неправильное поведение,
-                        // иначе будут прилетать дефолты селекта в табы, которые не игнорят.
-                        const fromInTabs =
-                            isItemWithTabs(item) && item.data.tabs.some(({id}) => id === from);
-                        return (from === item.id || fromInTabs) && invertedMapIds[to];
-                    }
-                    return from === mapIds[item.id] && invertedMapIds[to];
-                })
-                .map(({to}) => invertedMapIds[to]),
-        };
-    }, {});
+
+    const itemsIgnores: Record<string, string[]> = {};
+    for (const item of items) {
+        itemsIgnores[item.id] = ignores
+            .filter(({from, to}) => {
+                if (isFirstVersion) {
+                    // В первой версии был баг - если есть игнор на один таб, то весь виджет игнорит селектор.
+                    // Повторяем это неправильное поведение,
+                    // иначе будут прилетать дефолты селекта в табы, которые не игнорят.
+                    const fromInTabs =
+                        isItemWithTabs(item) && item.data.tabs.some(({id}) => id === from);
+                    return (from === item.id || fromInTabs) && invertedMapIds[to];
+                }
+                return from === mapIds[item.id] && invertedMapIds[to];
+            })
+            .map(({to}) => invertedMapIds[to]);
+    }
+    return itemsIgnores;
 }
 
 export function mergeParamsWithAliases({

--- a/src/shared/modules/state-and-params.ts
+++ b/src/shared/modules/state-and-params.ts
@@ -230,7 +230,8 @@ export function getItemsParams({
         {} as Record<string, (ConfigItem | ConfigItemGroup)[]>,
     );
 
-    return items.reduce((itemsParams: GetItemsParamsReturn, item: ConfigItem) => {
+    const itemsParams: GetItemsParamsReturn = {};
+    for (const item of items) {
         const {id, namespace} = item;
 
         const getMergedParams = (params: StringParams, actionParams?: StringParams) =>
@@ -261,17 +262,16 @@ export function getItemsParams({
                     return groupItemParams;
                 }, {});
 
-            return {...itemsParams, [id]: groupParams};
+            itemsParams[id] = groupParams;
+            continue;
         }
 
-        return {
-            ...itemsParams,
-            [id]: getItemParams({
-                item,
-                ...paramsOptions,
-            }),
-        };
-    }, {});
+        itemsParams[id] = getItemParams({
+            item,
+            ...paramsOptions,
+        });
+    }
+    return itemsParams;
 }
 
 export function getItemsState({
@@ -305,22 +305,17 @@ export function getItemsStateAndParams({
     const state = getItemsState({config, itemsStateAndParams});
     const uniqIds = new Set([...Object.keys(params), ...Object.keys(state)]);
 
-    const result: ItemsStateAndParams = Array.from(uniqIds).reduce(
-        (acc: ItemsStateAndParams, id) => {
-            const data = {} as ItemStateAndParams;
-            if (id in params) {
-                data.params = params[id];
-            }
-            if (id in state) {
-                data.state = state[id];
-            }
-            return {
-                ...acc,
-                [id]: data,
-            };
-        },
-        {},
-    );
+    const result: ItemsStateAndParamsBase = {};
+    for (const id of uniqIds) {
+        const data = {} as ItemStateAndParams;
+        if (id in params) {
+            data.params = params[id];
+        }
+        if (id in state) {
+            data.state = state[id];
+        }
+        result[id] = data;
+    }
     const version = getCurrentVersion(itemsStateAndParams);
     if (version === 1) {
         return result;


### PR DESCRIPTION
- `getMapItemsIgnores`, `getItemsParams` and `getItemsStateAndParams` rebuilt their accumulator on every item (`{...acc, [id]: value}`), which is O(n²) in the number of items
- on a dashboard with 19k items `getMapItemsIgnores` alone took ~72s, after the change ~8ms